### PR TITLE
Add Indian equity research automation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Before we [dive in](#dive-into-machine-learning), here are some notable projects
 * [AlgorithmWatch](https://algorithmwatch.org/en/) — [newsletter](https://algorithmwatch.org/en/newsletter/) — "a non-profit research and advocacy organization that is committed to watch, unpack and analyze automated decision-making (ADM) systems and their impact on society."
 * [`daviddao/awful-ai`](https://github.com/daviddao/awful-ai) — "Awful AI is a curated list to track current scary usages of AI — hoping to raise awareness"
 * [`humanetech-community/awesome-humane-tech`](https://github.com/humanetech-community/awesome-humane-tech) — "Promoting solutions that improve wellbeing, freedom and society"
+* [Indian Equity Research Automation](./indian-equity-research) — example Python script for generating simple research reports for NSE-listed stocks
 
 #### Code against climate change
 

--- a/indian-equity-research/README.md
+++ b/indian-equity-research/README.md
@@ -1,0 +1,19 @@
+# Indian Equity Research Automation
+
+This example shows how to generate a simple research report for an Indian equity using Python.
+
+The script relies on the [`yfinance`](https://pypi.org/project/yfinance/) package to fetch historical price data from Yahoo Finance. Metrics like daily returns and moving averages are computed with `pandas` and written to a Markdown file.
+
+## Requirements
+
+```bash
+pip install yfinance pandas
+```
+
+## Usage
+
+```bash
+python generate_report.py RELIANCE.NS --period 6mo --output reliance_report.md
+```
+
+This command downloads six months of price data for Reliance Industries (ticker `RELIANCE.NS`) and writes a basic Markdown report to `reliance_report.md`.

--- a/indian-equity-research/generate_report.py
+++ b/indian-equity-research/generate_report.py
@@ -1,0 +1,48 @@
+import argparse
+import yfinance as yf
+
+import pandas as pd
+
+def fetch_stock_data(ticker: str, period: str = "1y") -> pd.DataFrame:
+    """Fetch historical data for a ticker from Yahoo Finance."""
+    stock = yf.Ticker(ticker)
+    hist = stock.history(period=period)
+    return hist
+
+def compute_metrics(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute common statistics for the equity."""
+    df = df.copy()
+    df["Daily Return"] = df["Close"].pct_change()
+    df["50MA"] = df["Close"].rolling(window=50).mean()
+    df["200MA"] = df["Close"].rolling(window=200).mean()
+    return df
+
+def generate_summary(ticker: str, df: pd.DataFrame) -> str:
+    last = df.iloc[-1]
+    summary = f"""# {ticker} Equity Report
+
+- Last Close: {last['Close']:.2f}
+- Volume: {int(last['Volume'])}
+
+## Moving Averages
+- 50-day MA: {last['50MA']:.2f}
+- 200-day MA: {last['200MA']:.2f}
+"""
+    return summary
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a simple equity report")
+    parser.add_argument("ticker", help="Ticker symbol. Use the .NS suffix for NSE.")
+    parser.add_argument("--period", default="1y", help="Data period to download")
+    parser.add_argument("--output", default="report.md", help="Output markdown file")
+    args = parser.parse_args()
+
+    hist = fetch_stock_data(args.ticker, period=args.period)
+    hist = compute_metrics(hist)
+    summary = generate_summary(args.ticker, hist)
+    with open(args.output, "w") as f:
+        f.write(summary)
+    print(f"Report written to {args.output}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Indian equity research report generator example script
- document requirements and usage in a new README
- link to the example in the main README

## Testing
- `python3 -m py_compile indian-equity-research/generate_report.py`


------
https://chatgpt.com/codex/tasks/task_e_6854c8564a6c8322b9faa2a79779e6fb