### PR TITLE
Add WhatsApp collections MVP backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ----
 
+## WhatsApp Collections MVP
+
+A new FastAPI backend lives in [`backend/`](backend/README.md). It ingests invoice CSVs, schedules WhatsApp-ready reminders, captures promise-to-pay responses, and reconciles bank statements for SMEs. Follow the backend README for installation and usage instructions.
+
 ### Initiatives
 
 Before we [dive in](#dive-into-machine-learning), here are some notable projects and initiatives that might interest you as well.

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,38 @@
+# WhatsApp Collections MVP Backend
+
+This directory contains a FastAPI backend that automates invoice delivery, reminder scheduling, promise-to-pay workflows, and bank reconciliation for WhatsApp-first SME collections.
+
+## Getting started
+
+1. **Install dependencies** (preferably in a virtual environment):
+
+   ```bash
+   cd backend
+   pip install -e .[dev]
+   ```
+
+2. **Run the API server**:
+
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+   The server exposes interactive API docs at [http://localhost:8000/docs](http://localhost:8000/docs).
+
+3. **Run the test suite**:
+
+   ```bash
+   pytest
+   ```
+
+## Data flows covered in the MVP
+
+- **Invoice ingestion:** Upload CSV exports from Zoho/Tally/Vyapar to create invoices and automatically schedule smart reminders that respect business hours and key Indian holidays.
+- **Promise-to-pay capture:** Snooze active reminders until the promised payment date and schedule a follow-up automatically.
+- **Bank reconciliation:** Import bank statement CSVs, match payments to outstanding invoices with fuzzy amount/date checks, and mark invoices as paid.
+
+## Next steps
+
+- Plug in a WhatsApp Business API provider for actual message delivery.
+- Extend the holiday calendar and reminder heuristics based on pilot feedback.
+- Add user authentication and multi-tenant dashboards.

--- a/backend/app/bank_parser.py
+++ b/backend/app/bank_parser.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import date
+from io import StringIO
+
+
+@dataclass
+class ParsedPayment:
+    payment_date: date
+    amount: float
+    reference: str | None
+    description: str | None
+
+
+REQUIRED_COLUMNS = {
+    "date",
+    "amount",
+}
+
+
+class BankCSVParserError(ValueError):
+    """Raised when bank statement CSV parsing fails."""
+
+
+def parse_bank_csv(raw_csv: str) -> list[ParsedPayment]:
+    reader = csv.DictReader(StringIO(raw_csv))
+    if reader.fieldnames is None:
+        raise BankCSVParserError("Missing CSV header row")
+
+    lower = [col.strip().lower() for col in reader.fieldnames]
+    missing = REQUIRED_COLUMNS - set(lower)
+    if missing:
+        raise BankCSVParserError(f"CSV missing required columns: {', '.join(sorted(missing))}")
+
+    payments: list[ParsedPayment] = []
+    for idx, row in enumerate(reader, start=2):
+        try:
+            payment_date = date.fromisoformat(row.get("date", "").strip())
+            amount = float(row.get("amount", "0").strip())
+            reference = row.get("reference")
+            description = row.get("description")
+        except Exception as exc:  # noqa: BLE001
+            raise BankCSVParserError(f"Row {idx} is invalid: {exc}") from exc
+
+        payments.append(
+            ParsedPayment(
+                payment_date=payment_date,
+                amount=amount,
+                reference=reference.strip() if isinstance(reference, str) else None,
+                description=description.strip() if isinstance(description, str) else None,
+            )
+        )
+
+    return payments

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,16 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application configuration with sane defaults for the MVP."""
+
+    database_url: str = "sqlite:///./app.db"
+    timezone: str = "Asia/Kolkata"
+    reminder_start_hour: int = 9
+    reminder_end_hour: int = 18
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,17 @@
+from collections.abc import Generator
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from .config import get_settings
+
+settings = get_settings()
+engine = create_engine(settings.database_url, connect_args={"check_same_thread": False})
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Generator[Session, None, None]:
+    with Session(engine) as session:
+        yield session

--- a/backend/app/invoice_parser.py
+++ b/backend/app/invoice_parser.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import date
+from io import StringIO
+
+
+@dataclass
+class ParsedInvoice:
+    invoice_number: str
+    customer_name: str
+    customer_phone: str
+    amount: float
+    due_date: date
+
+
+REQUIRED_COLUMNS = {
+    "invoice_number",
+    "customer_name",
+    "customer_phone",
+    "amount",
+    "due_date",
+}
+
+
+class InvoiceCSVParserError(ValueError):
+    """Raised when the incoming CSV payload cannot be parsed."""
+
+
+def parse_invoice_csv(raw_csv: str) -> list[ParsedInvoice]:
+    """Parse a CSV string exported from Zoho/Tally/Vyapar into invoices.
+
+    The MVP expects a header row with at least the required columns. Dates must be
+    provided in ISO format (YYYY-MM-DD)."""
+
+    reader = csv.DictReader(StringIO(raw_csv))
+    if reader.fieldnames is None:
+        raise InvoiceCSVParserError("Missing CSV header row")
+
+    missing = REQUIRED_COLUMNS - set(col.strip().lower() for col in reader.fieldnames)
+    if missing:
+        raise InvoiceCSVParserError(f"CSV missing required columns: {', '.join(sorted(missing))}")
+
+    invoices: list[ParsedInvoice] = []
+    for idx, row in enumerate(reader, start=2):
+        try:
+            invoice_number = row["invoice_number"].strip()
+            customer_name = row["customer_name"].strip()
+            customer_phone = row["customer_phone"].strip()
+            amount = float(row["amount"].strip())
+            due_date = date.fromisoformat(row["due_date"].strip())
+        except Exception as exc:  # noqa: BLE001 - convert to parser error
+            raise InvoiceCSVParserError(f"Row {idx} is invalid: {exc}") from exc
+
+        invoices.append(
+            ParsedInvoice(
+                invoice_number=invoice_number,
+                customer_name=customer_name,
+                customer_phone=customer_phone,
+                amount=amount,
+                due_date=due_date,
+            )
+        )
+
+    return invoices

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from fastapi import Depends, FastAPI, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from sqlmodel import Session, select
+
+from . import reminders
+from .bank_parser import BankCSVParserError, parse_bank_csv
+from .config import get_settings
+from .database import get_session, init_db
+from .invoice_parser import InvoiceCSVParserError, parse_invoice_csv
+from .models import Company, Invoice, Reminder
+from .reconciliation import record_payments, reconcile_payments
+
+app = FastAPI(title="WhatsApp Collections MVP")
+settings = get_settings()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+
+
+@app.post("/companies", response_model=Company)
+def create_company(company: Company, session: Session = Depends(get_session)) -> Company:
+    if company.id is not None:
+        raise HTTPException(status_code=400, detail="New companies cannot specify an id")
+    session.add(company)
+    session.commit()
+    session.refresh(company)
+    return company
+
+
+@app.get("/companies/{company_id}", response_model=Company)
+def get_company(company_id: int, session: Session = Depends(get_session)) -> Company:
+    company = session.get(Company, company_id)
+    if not company:
+        raise HTTPException(status_code=404, detail="Company not found")
+    return company
+
+
+@app.post("/companies/{company_id}/invoices/upload")
+def upload_invoices(company_id: int, file: UploadFile, session: Session = Depends(get_session)) -> dict:
+    company = session.get(Company, company_id)
+    if not company:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+    raw_csv = file.file.read().decode("utf-8")
+    try:
+        parsed_invoices = parse_invoice_csv(raw_csv)
+    except InvoiceCSVParserError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    created: list[int] = []
+    now = datetime.utcnow()
+    for parsed in parsed_invoices:
+        invoice = Invoice(
+            company_id=company_id,
+            invoice_number=parsed.invoice_number,
+            customer_name=parsed.customer_name,
+            customer_phone=parsed.customer_phone,
+            amount=parsed.amount,
+            due_date=parsed.due_date,
+            status="draft",
+        )
+        session.add(invoice)
+        session.commit()
+        session.refresh(invoice)
+        invoice.company = company
+        reminders.schedule_initial_reminders(invoice, session, now)
+        session.commit()
+        created.append(invoice.id)
+    return {"invoices_created": created}
+
+
+@app.get("/companies/{company_id}/invoices", response_model=list[Invoice])
+def list_invoices(company_id: int, session: Session = Depends(get_session)) -> list[Invoice]:
+    invoices = session.exec(select(Invoice).where(Invoice.company_id == company_id)).all()
+    return invoices
+
+
+@app.get("/invoices/{invoice_id}", response_model=Invoice)
+def get_invoice(invoice_id: int, session: Session = Depends(get_session)) -> Invoice:
+    invoice = session.get(Invoice, invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+    return invoice
+
+
+@app.post("/invoices/{invoice_id}/promise")
+def record_promise(invoice_id: int, payload: dict[str, str], session: Session = Depends(get_session)) -> dict:
+    invoice = session.get(Invoice, invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+    promise_date_str = payload.get("promise_date")
+    note = payload.get("note")
+    if not promise_date_str:
+        raise HTTPException(status_code=400, detail="promise_date is required")
+
+    try:
+        promise_date = date.fromisoformat(promise_date_str)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid promise_date format") from exc
+
+    invoice.promise_to_pay_at = promise_date
+    invoice.promise_note = note
+    session.add(invoice)
+    reminders.reschedule_for_promise(invoice, session)
+    session.commit()
+    return {"status": "snoozed_until", "promise_date": promise_date.isoformat()}
+
+
+@app.post("/companies/{company_id}/bank/upload")
+def upload_bank_statement(company_id: int, file: UploadFile, session: Session = Depends(get_session)) -> dict:
+    company = session.get(Company, company_id)
+    if not company:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+    raw_csv = file.file.read().decode("utf-8")
+    try:
+        parsed_payments = parse_bank_csv(raw_csv)
+    except BankCSVParserError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    payments = record_payments(
+        session,
+        company_id,
+        (
+            (payment.payment_date, payment.amount, payment.reference, payment.description)
+            for payment in parsed_payments
+        ),
+    )
+    matches = reconcile_payments(session, company_id)
+    return {
+        "payments_ingested": [payment.id for payment in payments],
+        "matches": [
+            {
+                "payment_id": payment.id,
+                "invoice_id": invoice.id,
+                "invoice_number": invoice.invoice_number,
+            }
+            for payment, invoice in matches
+        ],
+    }
+
+
+@app.get("/companies/{company_id}/reminders", response_model=list[Reminder])
+def list_reminders(company_id: int, session: Session = Depends(get_session)) -> list[Reminder]:
+    reminders_query = session.exec(
+        select(Reminder).join(Invoice).where(Invoice.company_id == company_id)
+    )
+    return reminders_query.all()
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok", "timezone": settings.timezone}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class Company(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    timezone: str = "Asia/Kolkata"
+
+    invoices: list["Invoice"] = Relationship(back_populates="company")
+    payments: list["Payment"] = Relationship(back_populates="company")
+
+
+class Invoice(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    company_id: int = Field(foreign_key="company.id")
+    invoice_number: str
+    customer_name: str
+    customer_phone: str
+    amount: float
+    due_date: date
+    currency: str = "INR"
+    status: str = Field(default="draft", index=True)
+    promise_to_pay_at: Optional[date] = Field(default=None)
+    promise_note: Optional[str] = None
+    last_reminder_at: Optional[datetime] = Field(default=None, index=True)
+
+    company: Company = Relationship(back_populates="invoices")
+    reminders: list["Reminder"] = Relationship(back_populates="invoice")
+    payments: list["Payment"] = Relationship(back_populates="invoice")
+
+
+class Reminder(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    invoice_id: int = Field(foreign_key="invoice.id")
+    scheduled_for: datetime = Field(index=True)
+    kind: str = Field(default="initial")
+    status: str = Field(default="pending", index=True)
+
+    invoice: Invoice = Relationship(back_populates="reminders")
+
+
+class Payment(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    company_id: int = Field(foreign_key="company.id")
+    invoice_id: Optional[int] = Field(default=None, foreign_key="invoice.id")
+    payment_date: date
+    amount: float
+    reference: Optional[str] = None
+    description: Optional[str] = None
+    matched: bool = Field(default=False, index=True)
+
+    invoice: Optional[Invoice] = Relationship(back_populates="payments")
+    company: Company = Relationship(back_populates="payments")

--- a/backend/app/reconciliation.py
+++ b/backend/app/reconciliation.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Iterable
+
+from sqlmodel import Session, select
+
+from .models import Invoice, Payment
+
+
+MATCH_WINDOW_DAYS = 2
+AMOUNT_TOLERANCE = 1.0
+
+
+def _is_amount_match(invoice: Invoice, payment: Payment) -> bool:
+    return abs(invoice.amount - payment.amount) <= AMOUNT_TOLERANCE
+
+
+def _is_date_match(invoice: Invoice, payment: Payment) -> bool:
+    lower = invoice.due_date - timedelta(days=MATCH_WINDOW_DAYS)
+    upper = invoice.due_date + timedelta(days=MATCH_WINDOW_DAYS)
+    return lower <= payment.payment_date <= upper
+
+
+def reconcile_payments(session: Session, company_id: int) -> list[tuple[Payment, Invoice]]:
+    invoices = session.exec(
+        select(Invoice).where(Invoice.company_id == company_id, Invoice.status != "paid")
+    ).all()
+    payments = session.exec(
+        select(Payment).where(Payment.company_id == company_id, Payment.matched.is_(False)).order_by(Payment.payment_date)
+    ).all()
+
+    matches: list[tuple[Payment, Invoice]] = []
+    for payment in payments:
+        candidate = next(
+            (
+                invoice
+                for invoice in invoices
+                if _is_amount_match(invoice, payment) and _is_date_match(invoice, payment)
+            ),
+            None,
+        )
+        if candidate:
+            payment.invoice_id = candidate.id
+            payment.matched = True
+            candidate.status = "paid"
+            session.add(payment)
+            session.add(candidate)
+            matches.append((payment, candidate))
+    session.commit()
+    return matches
+
+
+def record_payments(
+    session: Session,
+    company_id: int,
+    payments: Iterable[tuple[date, float, str | None, str | None]],
+) -> list[Payment]:
+    stored: list[Payment] = []
+    for payment_date, amount, reference, description in payments:
+        payment = Payment(
+            company_id=company_id,
+            payment_date=payment_date,
+            amount=amount,
+            reference=reference,
+            description=description,
+        )
+        session.add(payment)
+        stored.append(payment)
+    session.commit()
+    for payment in stored:
+        session.refresh(payment)
+    return stored

--- a/backend/app/reminders.py
+++ b/backend/app/reminders.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from sqlmodel import Session, select
+
+from .config import get_settings
+from .models import Invoice, Reminder
+
+SETTINGS = get_settings()
+
+# Minimal festival calendar for the MVP. Extendable via database/config later.
+FESTIVAL_DATES = {
+    (1, 26),   # Republic Day
+    (8, 15),   # Independence Day
+    (10, 2),   # Gandhi Jayanti
+    (11, 1),   # Diwali (approximate, adjust yearly)
+}
+
+
+def _is_festival(candidate: date) -> bool:
+    return (candidate.month, candidate.day) in FESTIVAL_DATES
+
+
+def _is_business_day(candidate: date) -> bool:
+    # Treat Sunday as non-working; Saturday optional but included for MVP simplicity.
+    return candidate.weekday() < 6 and not _is_festival(candidate)
+
+
+def _combine(candidate_date: date, hour: int, tz: ZoneInfo) -> datetime:
+    base = datetime.combine(candidate_date, time(hour=hour))
+    return base.replace(tzinfo=tz)
+
+
+def next_allowed_datetime(start: datetime, tz_name: str | None = None) -> datetime:
+    tz = ZoneInfo(tz_name or SETTINGS.timezone)
+    current = start.astimezone(tz)
+
+    # Align to next allowed hour window.
+    while True:
+        if not _is_business_day(current.date()) or current.hour >= SETTINGS.reminder_end_hour:
+            current = _combine(current.date() + timedelta(days=1), SETTINGS.reminder_start_hour, tz)
+            continue
+        if current.hour < SETTINGS.reminder_start_hour:
+            current = current.replace(hour=SETTINGS.reminder_start_hour, minute=0, second=0, microsecond=0)
+        break
+    return current
+
+
+def schedule_initial_reminders(invoice: Invoice, session: Session, now: datetime) -> list[Reminder]:
+    tz = ZoneInfo(invoice.company.timezone if invoice.company else SETTINGS.timezone)
+    planned: list[datetime] = []
+    current = next_allowed_datetime(now, tz.key)
+    planned.append(current)
+
+    due_minus_one = invoice.due_date - timedelta(days=1)
+    if due_minus_one >= now.date():
+        planned.append(next_allowed_datetime(_combine(due_minus_one, SETTINGS.reminder_start_hour, tz), tz.key))
+
+    planned.append(next_allowed_datetime(_combine(invoice.due_date + timedelta(days=1), SETTINGS.reminder_start_hour, tz), tz.key))
+    planned.append(next_allowed_datetime(_combine(invoice.due_date + timedelta(days=4), SETTINGS.reminder_start_hour, tz), tz.key))
+
+    reminders: list[Reminder] = []
+    for idx, scheduled_for in enumerate(planned):
+        reminder = Reminder(
+            invoice_id=invoice.id,
+            scheduled_for=scheduled_for,
+            kind="initial" if idx == 0 else "follow_up",
+        )
+        session.add(reminder)
+        reminders.append(reminder)
+
+    invoice.status = "scheduled"
+    session.add(invoice)
+    return reminders
+
+
+def reschedule_for_promise(invoice: Invoice, session: Session) -> Reminder:
+    # Cancel pending reminders
+    pending_reminders = session.exec(
+        select(Reminder).where(Reminder.invoice_id == invoice.id, Reminder.status == "pending")
+    ).all()
+    for reminder in pending_reminders:
+        reminder.status = "cancelled"
+        session.add(reminder)
+
+    if not invoice.promise_to_pay_at:
+        raise ValueError("Invoice must have promise_to_pay_at before rescheduling")
+
+    tz = ZoneInfo(invoice.company.timezone if invoice.company else SETTINGS.timezone)
+    follow_up = next_allowed_datetime(_combine(invoice.promise_to_pay_at, SETTINGS.reminder_start_hour, tz), tz.key)
+
+    reminder = Reminder(
+        invoice_id=invoice.id,
+        scheduled_for=follow_up,
+        kind="promise_follow_up",
+    )
+    session.add(reminder)
+    invoice.status = "waiting_for_payment"
+    session.add(invoice)
+    return reminder

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "whatsapp_collections_mvp"
+version = "0.1.0"
+description = "MVP backend for WhatsApp-first collections and reconciliation"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.27.0",
+    "sqlmodel>=0.0.16",
+    "python-multipart>=0.0.9",
+    "pydantic-settings>=2.2.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "httpx>=0.27.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterator
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from app.models import Company
+
+
+@pytest.fixture(name="session")
+def session_fixture() -> Iterator[Session]:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        company = Company(name="Test Co", timezone="Asia/Kolkata")
+        session.add(company)
+        session.commit()
+        session.refresh(company)
+        yield session
+
+
+@pytest.fixture(name="company")
+def company_fixture(session: Session) -> Company:
+    company = session.exec(select(Company)).first()
+    assert company is not None
+    return company
+
+
+@pytest.fixture(name="now")
+def now_fixture() -> datetime:
+    return datetime(2024, 8, 14, 8, 30)

--- a/backend/tests/test_parsers.py
+++ b/backend/tests/test_parsers.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from app.invoice_parser import InvoiceCSVParserError, parse_invoice_csv
+from app.bank_parser import BankCSVParserError, parse_bank_csv
+
+
+def test_parse_invoice_csv_success() -> None:
+    csv_data = ("invoice_number,customer_name,customer_phone,amount,due_date\n"
+                "INV-1,Acme,9999999999,1500.50,2024-08-20\n")
+    invoices = parse_invoice_csv(csv_data)
+    assert len(invoices) == 1
+    assert invoices[0].invoice_number == "INV-1"
+    assert invoices[0].amount == 1500.50
+
+
+@pytest.mark.parametrize("csv_data", ["invoice_number,amount\n1,100\n", "\n"])
+def test_parse_invoice_csv_failure(csv_data: str) -> None:
+    with pytest.raises(InvoiceCSVParserError):
+        parse_invoice_csv(csv_data)
+
+
+def test_parse_bank_csv_success() -> None:
+    csv_data = "date,amount,reference,description\n2024-08-10,1500.50,NEFT123,Payment\n"
+    payments = parse_bank_csv(csv_data)
+    assert len(payments) == 1
+    assert payments[0].amount == 1500.50
+
+
+@pytest.mark.parametrize("csv_data", ["date,reference\n2024-08-10,NEFT\n", "\n"])
+def test_parse_bank_csv_failure(csv_data: str) -> None:
+    with pytest.raises(BankCSVParserError):
+        parse_bank_csv(csv_data)

--- a/backend/tests/test_reconciliation.py
+++ b/backend/tests/test_reconciliation.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import date
+
+from sqlmodel import Session
+
+from app.models import Company, Invoice, Payment
+from app.reconciliation import reconcile_payments
+
+
+def test_reconcile_payments_matches_by_amount_and_date(session: Session, company: Company) -> None:
+    invoice = Invoice(
+        company_id=company.id,
+        invoice_number="INV-100",
+        customer_name="Acme",
+        customer_phone="9999999999",
+        amount=5000.0,
+        due_date=date(2024, 8, 20),
+        status="scheduled",
+    )
+    payment = Payment(
+        company_id=company.id,
+        payment_date=date(2024, 8, 21),
+        amount=5000.0,
+        reference="NEFT999",
+        description="Invoice payment",
+    )
+    session.add(invoice)
+    session.add(payment)
+    session.commit()
+    session.refresh(invoice)
+    session.refresh(payment)
+
+    matches = reconcile_payments(session, company.id)
+    assert len(matches) == 1
+    match_payment, match_invoice = matches[0]
+    assert match_payment.invoice_id == invoice.id
+    assert match_invoice.status == "paid"

--- a/backend/tests/test_reminders.py
+++ b/backend/tests/test_reminders.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from sqlmodel import Session
+
+from app import reminders
+from app.models import Company, Invoice
+
+
+def test_next_allowed_datetime_respects_business_hours(now: datetime) -> None:
+    candidate = reminders.next_allowed_datetime(now, "Asia/Kolkata")
+    assert candidate.hour == 9
+    assert candidate.tzinfo is not None
+
+
+def test_next_allowed_datetime_skips_festival() -> None:
+    start = datetime(2024, 8, 15, 10, 0)  # Independence Day
+    candidate = reminders.next_allowed_datetime(start, "Asia/Kolkata")
+    assert candidate.date() == datetime(2024, 8, 16, 9, 0).date()
+
+
+def test_schedule_initial_reminders_creates_followups(session: Session, company: Company, now: datetime) -> None:
+    invoice = Invoice(
+        company_id=company.id,
+        invoice_number="INV-1",
+        customer_name="Acme",
+        customer_phone="9999999999",
+        amount=1000.0,
+        due_date=now.date() + timedelta(days=5),
+    )
+    session.add(invoice)
+    session.commit()
+    session.refresh(invoice)
+    invoice.company = company
+
+    reminders_created = reminders.schedule_initial_reminders(invoice, session, now)
+    session.commit()
+
+    assert len(reminders_created) == 4
+    kinds = {rem.kind for rem in reminders_created}
+    assert kinds == {"initial", "follow_up"}


### PR DESCRIPTION
## Summary
- add a FastAPI backend for onboarding companies, importing invoices, recording promises-to-pay, and reconciling bank statements
- implement CSV parsers, reminder scheduling heuristics, and payment matching utilities backing the API
- document setup and provide unit tests covering parsing, scheduling, and reconciliation helpers

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'sqlmodel' because required dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd538ac788322a55dcbb62c4407b1